### PR TITLE
Feature/fullscreen layout

### DIFF
--- a/public_html/wp-content/themes/jampack/assets/js/main.js
+++ b/public_html/wp-content/themes/jampack/assets/js/main.js
@@ -169,3 +169,113 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 });
+
+window.jampackFullscreen = {
+
+    /**
+     * Launches fullscreen mode.
+     * @param {string} selector - Optional CSS selector. If empty, auto-detects game elements
+     * @returns {boolean} True if fullscreen was successfully launched, false otherwise
+     * @example
+     * // Auto-detect game element
+     * jampackFullscreen.launch('');
+     * 
+     * // Target specific element
+     * jampackFullscreen.launch('#my-game-iframe');
+     */
+    launch: function(selector) {
+        const element = this.findGameElement(selector);
+        if (!element) {
+            console.warn('Jampack Fullscreen: No element found for selector:', selector);
+            return false;
+        }
+        
+        return this.enterFullscreen(element);
+    },
+    
+    /**
+     * Finds a suitable game element to make fullscreen
+     * @param {string} selector - CSS selector for target element
+     * @returns {Element|null} The DOM element to make fullscreen, or null if none found
+     * @private
+     */
+    findGameElement: function(selector) {
+        if (selector && selector.trim()) {
+            const element = document.querySelector(selector);
+            if (element) return element;
+        }
+        
+        const gameSelectors = [
+            '.game-container',
+            '.game-iframe', 
+            '.game-content',
+            '#game-container',
+            'iframe',
+            'canvas'
+        ];
+        
+        for (let sel of gameSelectors) {
+            const elements = document.querySelectorAll(sel);
+            if (elements.length > 0) {
+                // Return the container or the element itself
+                return elements[0].closest('.brxe-div, .bricks-element') || elements[0];
+            }
+        }
+        
+        return null;
+    },
+    
+    /**
+     * Enters fullscreen mode for the specified element using cross-browser API
+     * @param {Element} element - DOM element to make fullscreen
+     * @returns {boolean} True if fullscreen request was successful, false if not supported
+     * @private
+     */
+    enterFullscreen: function(element) {
+        if (element.requestFullscreen) {
+            element.requestFullscreen();
+        } else if (element.webkitRequestFullscreen) {
+            element.webkitRequestFullscreen();
+        } else if (element.mozRequestFullScreen) {
+            element.mozRequestFullScreen();
+        } else if (element.msRequestFullscreen) {
+            element.msRequestFullscreen();
+        } else {
+            return false;
+        }
+        return true;
+    },
+    
+    /**
+     * Exits fullscreen mode using cross-browser API
+     * @returns {void}
+     * @example
+     * jampackFullscreen.exit();
+     */
+    exit: function() {
+        if (document.exitFullscreen) {
+            document.exitFullscreen();
+        } else if (document.webkitExitFullscreen) {
+            document.webkitExitFullscreen();
+        } else if (document.mozCancelFullScreen) {
+            document.mozCancelFullScreen();
+        } else if (document.msExitFullscreen) {
+            document.msExitFullscreen();
+        }
+    },
+    
+    /**
+     * Checks if currently in fullscreen mode
+     * @returns {boolean} True if any element is currently in fullscreen, false otherwise
+     * @example
+     * if (jampackFullscreen.isActive()) {
+     *     console.log('Currently in fullscreen');
+     * }
+     */
+    isActive: function() {
+        return !!(document.fullscreenElement || 
+                 document.webkitFullscreenElement || 
+                 document.mozFullScreenElement || 
+                 document.msFullscreenElement);
+    }
+};

--- a/public_html/wp-content/themes/jampack/functions.php
+++ b/public_html/wp-content/themes/jampack/functions.php
@@ -1,6 +1,9 @@
 <?php
-
-require_once get_stylesheet_directory() . '/memberpress/init.php';
+require_once __DIR__ . '/memberpress/init.php';
+require_once __DIR__ . '/includes/elements/bricks-forms.php';
+require_once __DIR__ . '/includes/jampackDB/jampack-database.php';
+require_once __DIR__ . '/includes/config/jampack-config.php';
+require_once __DIR__ . '/includes/elements/games.php';
 
 function register_jampack_bricks_elements() {
 	$element_files = [
@@ -17,6 +20,8 @@ function register_jampack_bricks_elements() {
 }
 
 add_action( 'init', 'register_jampack_bricks_elements', 11 );
+
+// TODO: Pass all the stuff related to games to /includes/elements/games.php file
 
 function prefix_disable_gutenberg( $current_status, $post_type ) {
 	// Use your post type key instead of 'product'

--- a/public_html/wp-content/themes/jampack/functions.php
+++ b/public_html/wp-content/themes/jampack/functions.php
@@ -1,4 +1,5 @@
 <?php
+
 require_once __DIR__ . '/memberpress/init.php';
 require_once __DIR__ . '/includes/elements/bricks-forms.php';
 require_once __DIR__ . '/includes/jampackDB/jampack-database.php';

--- a/public_html/wp-content/themes/jampack/functions.php
+++ b/public_html/wp-content/themes/jampack/functions.php
@@ -1,15 +1,12 @@
 <?php
 
-require_once __DIR__ . '/memberpress/init.php';
-require_once __DIR__ . '/includes/elements/bricks-forms.php';
-require_once __DIR__ . '/includes/jampackDB/jampack-database.php';
-require_once __DIR__ . '/includes/config/jampack-config.php';
-require_once __DIR__ . '/includes/elements/games.php';
+require_once get_stylesheet_directory() . '/memberpress/init.php';
 
 function register_jampack_bricks_elements() {
 	$element_files = [
 		__DIR__ . '/includes/elements/Jampack_Game_Screenshots.php',
 		__DIR__ . '/includes/elements/Jampack_Game_Favorite_Button.php',
+		__DIR__ . '/includes/elements/Jampack_Game_Fullscreen_Button.php',
 		__DIR__ . '/includes/elements/Jampack_Tooltip.php',
 		__DIR__ . '/includes/elements/Jampack_Slider_Nested.php',
 	];
@@ -20,8 +17,6 @@ function register_jampack_bricks_elements() {
 }
 
 add_action( 'init', 'register_jampack_bricks_elements', 11 );
-
-// TODO: Pass all the stuff related to games to /includes/elements/games.php file
 
 function prefix_disable_gutenberg( $current_status, $post_type ) {
 	// Use your post type key instead of 'product'

--- a/public_html/wp-content/themes/jampack/includes/elements/Jampack_Game_Fullscreen_Button.php
+++ b/public_html/wp-content/themes/jampack/includes/elements/Jampack_Game_Fullscreen_Button.php
@@ -1,0 +1,149 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) exit; 
+
+/**
+ * Game Fullscreen Button element for Bricks Builder
+ * 
+ * Creates a button that launches fullscreen mode for game elements.
+ * Leverages Bricks' built-in button styling and adds custom fullscreen functionality.
+ * 
+ * @extends \Bricks\Element
+ */
+class Jampack_Game_Fullscreen_Button extends \Bricks\Element {
+	public $block    = 'core/button';
+	public $category = 'jampack';
+	public $name     = 'game-fullscreen-button';
+	public $icon     = 'ti-fullscreen';
+	public $tag      = 'span';
+
+	/**
+	 * Returns the display name for this element in Bricks Builder
+	 * 
+	 * @return string The localized element name
+	 */
+	public function get_label() {
+		return esc_html__( 'Game Fullscreen Button', 'jampack' );
+	}
+
+	/**
+	 * Defines the controls for The Fullscreen Button
+	 
+	 * @return void
+	 */
+	public function set_controls() {
+		$this->controls['tag'] = [
+			'label'          => esc_html__( 'HTML tag', 'bricks' ),
+			'type'           => 'text',
+			'hasDynamicData' => false,
+			'inline'         => true,
+			'placeholder'    => 'span',
+			'required'       => [ 'link', '=', '' ],
+		];
+
+		$this->controls['size'] = [
+			'label'       => esc_html__( 'Size', 'bricks' ),
+			'type'        => 'select',
+			'options'     => $this->control_options['buttonSizes'],
+			'inline'      => true,
+			'reset'       => true,
+			'placeholder' => esc_html__( 'Default', 'bricks' ),
+		];
+
+		$this->controls['style'] = [
+			'label'       => esc_html__( 'Style', 'bricks' ),
+			'type'        => 'select',
+			'options'     => $this->control_options['styles'],
+			'inline'      => true,
+			'reset'       => true,
+			'default'     => 'primary',
+			'placeholder' => esc_html__( 'None', 'bricks' ),
+		];
+
+		$this->controls['icon'] = [
+			'label' => esc_html__( 'Icon', 'bricks' ),
+			'type'  => 'icon',
+		];
+
+		// Custom control for fullscreen targeting
+		$this->controls['targetSelector'] = [
+			'tab'         => 'content',
+			'label'       => esc_html__( 'Target Selector', 'jampack' ),
+			'type'        => 'text',
+			'placeholder' => esc_html__( 'CSS selector (optional - auto-detects if empty)', 'jampack' ),
+			'description' => esc_html__( 'CSS selector for the game element to make fullscreen. Leave empty for auto-detection.', 'jampack' ),
+		];
+	}
+
+	/**
+	 * Renders the HTML output for the frontend
+	 * 
+	 * Generates a button element with fullscreen click handler.
+	 * Uses Bricks' built-in styling and adds custom onclick functionality.
+	 * 
+	 * @return void Echoes HTML directly
+	 */
+	public function render() {
+		$settings = $this->settings;
+
+		$this->set_attribute( '_root', 'class', 'bricks-button' );
+
+		if ( ! empty( $settings['size'] ) ) {
+			$this->set_attribute( '_root', 'class', $settings['size'] );
+		}
+
+		if ( ! empty( $settings['style'] ) ) {
+            $this->set_attribute( '_root', 'class', "bricks-background-{$settings['style']}" );
+		}
+
+		if ( isset( $settings['block'] ) ) {
+			$this->set_attribute( '_root', 'class', 'block' );
+		}
+
+		$text = 'Fullscreen';
+		$target_selector = ! empty( $settings['targetSelector'] ) ? $settings['targetSelector'] : '';
+
+		$on_click = "onClick='jampackFullscreen.launch(\"" . esc_attr( $target_selector ) . "\")'";
+
+		$output = "<{$this->tag} {$this->render_attributes( '_root' )} ${on_click}>";
+
+		// Set default fullscreen icon if none provided, always on the left
+		$icon = ! empty( $settings['icon'] ) ? self::render_icon( $settings['icon'] ) : self::render_icon(['library' => 'themify', 'icon' => 'ti-fullscreen']);
+		if ( $icon ) {
+			$output .= $icon;
+		}
+
+		// button text
+        $output .= 'Fullscreen';
+
+		$output .= "</{$this->tag}>";
+
+		echo $output;
+	}
+
+	/**
+	 * Provides template for Bricks Builder preview
+	 * 
+	 * This template shows how the element appears in the Bricks editor.
+	 * Uses the same structure as the frontend render method.
+	 * 
+	 * @return void Outputs JavaScript template
+	 */
+	public static function render_builder() { ?>
+		<script type="text/x-template" id="tmpl-bricks-element-game-fullscreen-button">
+			<component
+				:is="settings.link ? 'a' : settings.tag ? settings.tag : 'span'"
+				:class="[
+					'bricks-button',
+					settings.size ? settings.size : null,
+					settings.style ? `bricks-background-${settings.style}` : null,
+					settings.block ? 'block' : null,
+					'icon-left'
+				]">
+				<icon-svg :iconSettings="settings?.icon || {library: 'themify', icon: 'ti-fullscreen'}"/>
+				Fullscreen
+			</component>
+		</script>
+		<?php
+	}
+}


### PR DESCRIPTION
Added Jampack_Game_Fullscreen_Button Bricks element to toggle fullscreen for game content.

Provides a native fullscreen button option in Bricks Builder, enable fullscreen mode for embedded games.

Additional tweaks to the button like roundness, font style, or size can be adjusted in bricks render mode