### PR TITLE
Fix: logout redirect to /login, not WP login

### DIFF
--- a/public_html/wp-content/themes/jampack/functions.php
+++ b/public_html/wp-content/themes/jampack/functions.php
@@ -259,3 +259,8 @@ function filter_menu_by_membership( $items ) {
 
 add_filter( 'wp_get_nav_menu_items', 'filter_menu_by_membership', 10, 1 );
 
+// Logout redirects to /login - still requires user confirmation to logout
+add_action('wp_logout', function() {
+  wp_safe_redirect(home_url('/login'));
+  exit;
+});


### PR DESCRIPTION
Fix for this bug: https://trello.com/c/HhOzQ8tM

https://github.com/user-attachments/assets/53ef737a-41ff-4dad-84bb-301d7bade287

