### PR TITLE
Fix for Fullscreen on IOS devices

### DIFF
--- a/public_html/wp-content/themes/jampack/assets/css/style.css
+++ b/public_html/wp-content/themes/jampack/assets/css/style.css
@@ -17,6 +17,45 @@
     border: none !important;
 }
 
+/* Mobile fullscreen fallback (iOS Safari doesn't support Fullscreen API for non-video elements) */
+.jampack-fullscreen-active {
+    position: fixed !important;
+    top: 0 !important;
+    left: 0 !important;
+    width: 100% !important;
+    height: 100% !important;
+    min-height: 100vh !important;
+    min-height: 100dvh !important;
+    z-index: 9999 !important;
+    background: #000 !important;
+}
+
+.jampack-fullscreen-active iframe,
+.jampack-fullscreen-active canvas {
+    width: 100% !important;
+    height: 100% !important;
+}
+
+.jampack-fullscreen-exit-btn {
+    position: fixed;
+    bottom: calc(20px + env(safe-area-inset-bottom, 0));
+    right: calc(20px + env(safe-area-inset-right, 0));
+    z-index: 10000;
+    padding: 12px 20px;
+    background: linear-gradient(135deg, #6b4c9a 0%, #c94b8b 100%);
+    color: #fff;
+    border: none;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.jampack-fullscreen-exit-btn:hover {
+    opacity: 0.95;
+}
+
 .game-screenshot {
     margin: 0
 }

--- a/public_html/wp-content/themes/jampack/assets/css/style.css
+++ b/public_html/wp-content/themes/jampack/assets/css/style.css
@@ -36,24 +36,38 @@
     height: 100% !important;
 }
 
-.jampack-fullscreen-exit-btn {
+/* Mobile-only CSS fullscreen exit button (separate from the main Bricks fullscreen button) */
+.jampack-mobile-fullscreen-exit-btn {
     position: fixed;
     bottom: calc(20px + env(safe-area-inset-bottom, 0));
     right: calc(20px + env(safe-area-inset-right, 0));
     z-index: 10000;
-    padding: 12px 20px;
-    background: linear-gradient(135deg, #6b4c9a 0%, #c94b8b 100%);
+    padding: 6px;
+    width: 30px;
+    height: 30px;
+    /* Use the site’s orange theme color (see manifest/background_color/theme_color #FF6A4B) */
+    background: linear-gradient(135deg, #ff6a4b 0%, #ff8a4b 100%);
     color: #fff;
     border: none;
-    border-radius: 8px;
-    font-size: 14px;
-    font-weight: 600;
+    border-radius: 6px;
     cursor: pointer;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 3px 9px rgba(0, 0, 0, 0.3);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform 0.2s ease, opacity 0.2s ease;
 }
 
-.jampack-fullscreen-exit-btn:hover {
+.jampack-mobile-fullscreen-exit-btn:hover {
     opacity: 0.95;
+    transform: scale(1.05);
+}
+
+.jampack-mobile-fullscreen-exit-btn svg {
+    width: 15px;
+    height: 15px;
+    stroke: currentColor;
+    fill: none;
 }
 
 .game-screenshot {

--- a/public_html/wp-content/themes/jampack/assets/js/main.js
+++ b/public_html/wp-content/themes/jampack/assets/js/main.js
@@ -788,9 +788,11 @@ window.jampackFullscreen = {
         const exitBtn = document.createElement('button');
         exitBtn.type = 'button';
         exitBtn.id = exitBtnId;
-        exitBtn.className = 'jampack-fullscreen-exit-btn';
-        exitBtn.setAttribute('aria-label', 'Exit fullscreen');
-        exitBtn.innerHTML = 'Exit Fullscreen';
+        // This is the mobile/iOS CSS fullscreen exit button (separate from the main Bricks fullscreen button)
+        exitBtn.className = 'jampack-mobile-fullscreen-exit-btn';
+        exitBtn.setAttribute('aria-label', 'Exit mobile fullscreen');
+        // Mobile fullscreen exit icon (two overlapping squares)
+        exitBtn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3v3a2 2 0 0 1-2 2H3m18 0h-3a2 2 0 0 1-2-2V3m0 18v-3a2 2 0 0 1 2-2h3M3 16h3a2 2 0 0 1 2 2v3"/></svg>';
         exitBtn.addEventListener('click', () => this.exit());
 
         document.body.appendChild(exitBtn);

--- a/public_html/wp-content/themes/jampack/assets/js/main.js
+++ b/public_html/wp-content/themes/jampack/assets/js/main.js
@@ -671,8 +671,12 @@ document.addEventListener('DOMContentLoaded', function() {
 
 window.jampackFullscreen = {
 
+    /** @type {Element|null} Element currently in CSS fullscreen mode (mobile fallback) */
+    _cssFullscreenElement: null,
+
     /**
      * Launches fullscreen mode.
+     * Uses native Fullscreen API when supported; falls back to CSS-based fullscreen on iOS/mobile.
      * @param {string} selector - Optional CSS selector. If empty, auto-detects game elements
      * @returns {boolean} True if fullscreen was successfully launched, false otherwise
      * @example
@@ -690,6 +694,20 @@ window.jampackFullscreen = {
         }
         
         return this.enterFullscreen(element);
+    },
+
+    /**
+     * Checks if the native Fullscreen API is supported for non-video elements. (iOS related issue)).
+     * @returns {boolean}
+     */
+    supportsFullscreen: function() {
+        const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+            (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+        if (isIOS) return false;
+        return !!(document.fullscreenEnabled ||
+            document.webkitFullscreenEnabled ||
+            document.mozFullScreenEnabled ||
+            document.msFullscreenEnabled);
     },
     
     /**
@@ -725,33 +743,90 @@ window.jampackFullscreen = {
     },
     
     /**
-     * Enters fullscreen mode for the specified element using cross-browser API
+     * Enters fullscreen mode for the specified element.
+     * Uses native API when supported; falls back to CSS fullscreen on iOS/mobile.
      * @param {Element} element - DOM element to make fullscreen
-     * @returns {boolean} True if fullscreen request was successful, false if not supported
+     * @returns {boolean} True if fullscreen was entered (native or CSS fallback)
      * @private
      */
     enterFullscreen: function(element) {
-        if (element.requestFullscreen) {
-            element.requestFullscreen();
-        } else if (element.webkitRequestFullscreen) {
-            element.webkitRequestFullscreen();
-        } else if (element.mozRequestFullScreen) {
-            element.mozRequestFullScreen();
-        } else if (element.msRequestFullscreen) {
-            element.msRequestFullscreen();
-        } else {
-            return false;
+        if (this.supportsFullscreen()) {
+            if (element.requestFullscreen) {
+                element.requestFullscreen();
+            } else if (element.webkitRequestFullscreen) {
+                element.webkitRequestFullscreen();
+            } else if (element.mozRequestFullScreen) {
+                element.mozRequestFullScreen();
+            } else if (element.msRequestFullscreen) {
+                element.msRequestFullscreen();
+            } else {
+                this.enterCSSFullscreen(element);
+                return true;
+            }
+            return true;
         }
+        // iOS Safari and some mobile browsers: Fullscreen API only works for <video>
+        // Use CSS-based fullscreen fallback for games (iframe/canvas/div)
+        this.enterCSSFullscreen(element);
         return true;
+    },
+
+    /**
+     * CSS-based fullscreen fallback for mobile (iOS Safari doesn't support Fullscreen API for non-video elements).
+     * @param {Element} element - DOM element to make fullscreen
+     * @private
+     */
+    enterCSSFullscreen: function(element) {
+        if (this._cssFullscreenElement) {
+            this.exitCSSFullscreen();
+        }
+        this._cssFullscreenElement = element;
+        element.classList.add('jampack-fullscreen-active');
+        document.body.style.overflow = 'hidden';
+
+        const exitBtnId = 'jampack-fullscreen-exit-' + Date.now();
+        const exitBtn = document.createElement('button');
+        exitBtn.type = 'button';
+        exitBtn.id = exitBtnId;
+        exitBtn.className = 'jampack-fullscreen-exit-btn';
+        exitBtn.setAttribute('aria-label', 'Exit fullscreen');
+        exitBtn.innerHTML = 'Exit Fullscreen';
+        exitBtn.addEventListener('click', () => this.exit());
+
+        document.body.appendChild(exitBtn);
+        element.dataset.jampackExitBtnId = exitBtnId;
+    },
+
+    /**
+     * Exits CSS-based fullscreen mode.
+     * @private
+     */
+    exitCSSFullscreen: function() {
+        const element = this._cssFullscreenElement;
+        if (element) {
+            element.classList.remove('jampack-fullscreen-active');
+            const exitBtnId = element.dataset.jampackExitBtnId;
+            if (exitBtnId) {
+                const btn = document.getElementById(exitBtnId);
+                if (btn) btn.remove();
+                delete element.dataset.jampackExitBtnId;
+            }
+            this._cssFullscreenElement = null;
+        }
+        document.body.style.overflow = '';
     },
     
     /**
-     * Exits fullscreen mode using cross-browser API
+     * Exits fullscreen mode (native API or CSS fallback).
      * @returns {void}
      * @example
      * jampackFullscreen.exit();
      */
     exit: function() {
+        if (this._cssFullscreenElement) {
+            this.exitCSSFullscreen();
+            return;
+        }
         if (document.exitFullscreen) {
             document.exitFullscreen();
         } else if (document.webkitExitFullscreen) {
@@ -764,7 +839,7 @@ window.jampackFullscreen = {
     },
     
     /**
-     * Checks if currently in fullscreen mode
+     * Checks if currently in fullscreen mode (native or CSS fallback).
      * @returns {boolean} True if any element is currently in fullscreen, false otherwise
      * @example
      * if (jampackFullscreen.isActive()) {
@@ -772,9 +847,10 @@ window.jampackFullscreen = {
      * }
      */
     isActive: function() {
-        return !!(document.fullscreenElement || 
-                 document.webkitFullscreenElement || 
-                 document.mozFullScreenElement || 
-                 document.msFullscreenElement);
+        return !!(this._cssFullscreenElement ||
+            document.fullscreenElement ||
+            document.webkitFullscreenElement ||
+            document.mozFullScreenElement ||
+            document.msFullscreenElement);
     }
 };


### PR DESCRIPTION
### Root Issue

- iOS Safari doesn’t support the standard Fullscreen API for non-video elements, so games couldn’t reliably enter fullscreen on iOS.
- The existing fullscreen control didn’t clearly distinguish between the main fullscreen button and any mobile-specific behavior.

### Fix

- Added a CSS-based fullscreen “fallback” mode for mobile/iOS that makes the game container fill the viewport.
- Added a dedicated mobile fullscreen exit button that only appears in this CSS fullscreen mode and is clearly separate from the Bricks fullscreen button.