### PR TITLE
fix(theme): Play Pass default URL and tier 1269 landing

### DIFF
--- a/public_html/wp-content/themes/jampack/functions.php
+++ b/public_html/wp-content/themes/jampack/functions.php
@@ -211,7 +211,7 @@ function early_access_query_filter( $query_vars ) {
 			if ( in_array( "games", $post_type ) ) {
 				$user_id = get_current_user_id();
 				$member  = new MeprUser( $user_id );
-				if ( empty( array_intersect( [ 1270, 1271 ], $member->active_product_subscriptions() ) ) ) {
+				if ( empty( array_intersect( [ 1269, 1270, 1271 ], $member->active_product_subscriptions() ) ) ) {
 					$query_vars['date_query'] = array(
 						array(
 							'column' => 'post_date',
@@ -377,15 +377,17 @@ add_action('wp_head', 'add_games_manifest');
 
 function filter_menu_by_membership( $items ) {
 	if (!is_admin() && !current_user_can('administrator')) {
-		$page_to_remove = [1285, 1248];
+		$page_to_remove = [1285, 1248, 81];
 		$menu_to_remove = [];
 		if ( is_user_logged_in() ) {
 			$user_id = get_current_user_id();
 			$member  = new MeprUser( $user_id );
 			if ( in_array( 1271, $member->active_product_subscriptions() ) ) {
-				$page_to_remove = [ 1248 ];
+				$page_to_remove = [ 1248, 81 ];
 			} else if ( in_array( 1270, $member->active_product_subscriptions() ) ) {
-				$page_to_remove = [ 1285 ];
+				$page_to_remove = [ 1285, 81 ];
+			} else if ( in_array( 1269, $member->active_product_subscriptions() ) ) {
+				$page_to_remove = [ 1285, 1248 ];
 			}
 		} else {
 			$page_to_remove[] = 1672;

--- a/public_html/wp-content/themes/jampack/includes/config/jampack-config.php
+++ b/public_html/wp-content/themes/jampack/includes/config/jampack-config.php
@@ -16,3 +16,12 @@ define('JPCK_CHILDREN_RESTRICTED_GENRES', ['fighting', 'horror', 'first-person-s
 define('JPCK_USER_MENU_NAME', 'User Menu');
 define('JPCK_USER_MENU_ID', 41);
 define('JPCK_GAMESUBMISSION_LINK', '<li class="menu-item menu-item-type-custom menu-item-object-custom bricks-menu-item"><a href="/game-submission">Game Submission</a></li>');
+
+/**
+ * WordPress page ID for the Play Pass hub (canonical: https://jampack.org/play-pass/).
+ * Same idea as tier rows in jampack_subscription_tier_landing_map() (page IDs, not paths).
+ * Set to 0 in repo; override in wp-config.php on each environment with the real page ID, or leave 0 to resolve by slug {@see jampack_playpass_default_landing_url()}.
+ */
+if ( ! defined( 'JPCK_PLAYPASS_HUB_PAGE_ID' ) ) {
+	define( 'JPCK_PLAYPASS_HUB_PAGE_ID', 0 );
+}

--- a/public_html/wp-content/themes/jampack/includes/elements/playpass-redirections.php
+++ b/public_html/wp-content/themes/jampack/includes/elements/playpass-redirections.php
@@ -23,6 +23,7 @@ function jampack_subscription_tier_landing_map() {
     return [
         1271 => 1285,
         1270 => 1248,
+        1269 => 81,
     ];
 }
 
@@ -44,9 +45,21 @@ function jampack_landing_url_for_membership_product( $product_id ) {
 
 /**
  * Default landing for Play Pass products without a tier row in jampack_subscription_tier_landing_map().
+ * Uses the published "play-pass" page when present, otherwise /player-rewards/.
  */
 function jampack_playpass_default_landing_url() {
-    return home_url( '/player-rewards/' );
+    static $cached = null;
+    if ( null !== $cached ) {
+        return $cached;
+    }
+    $page = get_page_by_path( 'play-pass', OBJECT, 'page' );
+    if ( $page instanceof WP_Post ) {
+        $link = get_permalink( $page );
+        if ( is_string( $link ) ) {
+            return $cached = $link;
+        }
+    }
+    return $cached = home_url( '/player-rewards/' );
 }
 
 /**

--- a/public_html/wp-content/themes/jampack/includes/elements/playpass-redirections.php
+++ b/public_html/wp-content/themes/jampack/includes/elements/playpass-redirections.php
@@ -3,7 +3,7 @@ if (!defined('ABSPATH')) {
     die('You are not allowed to call this page directly.');
 }
 
-// TODO: Refactor subscription redirect helpers (Play Pass hub: /play-pass/).
+// TODO: Refactor subscription redirect helpers if tier list grows further.
 
 /**
  * Play Pass Subscription Redirections
@@ -13,9 +13,22 @@ if (!defined('ABSPATH')) {
  */
 
 /**
+ * Permalink for a WordPress page ID (Player+, Multipass, tier pages, Play Pass hub).
+ *
+ * @param int $page_id Page post ID.
+ * @return string Empty string if permalink is unavailable.
+ */
+function jampack_subscription_landing_permalink_for_page( $page_id ) {
+    $link = get_permalink( (int) $page_id );
+    return is_string( $link ) ? $link : '';
+}
+
+/**
  * MemberPress product ID => WordPress page ID for post-checkout / home / login landing.
  * Order matters: first match wins when a user has multiple tiers.
  * Kept in sync with filter_menu_by_membership() in functions.php.
+ *
+ * Tier pages (examples): 1271 → Player+ hub page, 1270 → Multipass hub page, 1269 → tier page.
  *
  * @return array<int, int>
  */
@@ -37,25 +50,32 @@ function jampack_landing_url_for_membership_product( $product_id ) {
     $map = jampack_subscription_tier_landing_map();
     $product_id = (int) $product_id;
     if ( isset( $map[ $product_id ] ) ) {
-        $link = get_permalink( $map[ $product_id ] );
-        return is_string( $link ) ? $link : null;
+        $link = jampack_subscription_landing_permalink_for_page( $map[ $product_id ] );
+        return $link !== '' ? $link : null;
     }
     return null;
 }
 
 /**
  * Default landing for Play Pass products without a tier row in jampack_subscription_tier_landing_map().
- * Canonical path: https://jampack.org/play-pass/ — uses the published page permalink when found, else /play-pass/.
+ * Uses the same page-ID → permalink pattern as tiers when JPCK_PLAYPASS_HUB_PAGE_ID is set;
+ * otherwise resolves the published page with slug {@see get_page_by_path()} `play-pass`, then /play-pass/.
  */
 function jampack_playpass_default_landing_url() {
     static $cached = null;
     if ( null !== $cached ) {
         return $cached;
     }
+    if ( defined( 'JPCK_PLAYPASS_HUB_PAGE_ID' ) && (int) JPCK_PLAYPASS_HUB_PAGE_ID > 0 ) {
+        $link = jampack_subscription_landing_permalink_for_page( (int) JPCK_PLAYPASS_HUB_PAGE_ID );
+        if ( $link !== '' ) {
+            return $cached = $link;
+        }
+    }
     $page = get_page_by_path( 'play-pass', OBJECT, 'page' );
     if ( $page instanceof WP_Post ) {
-        $link = get_permalink( $page );
-        if ( is_string( $link ) ) {
+        $link = jampack_subscription_landing_permalink_for_page( (int) $page->ID );
+        if ( $link !== '' ) {
             return $cached = $link;
         }
     }
@@ -80,8 +100,8 @@ function jampack_get_user_subscription_landing_url( $user_id = null ) {
     $ids = array_map( 'intval', (array) $ids );
     foreach ( jampack_subscription_tier_landing_map() as $product_id => $page_id ) {
         if ( in_array( (int) $product_id, $ids, true ) ) {
-            $link = get_permalink( (int) $page_id );
-            return is_string( $link ) ? $link : jampack_playpass_default_landing_url();
+            $link = jampack_subscription_landing_permalink_for_page( (int) $page_id );
+            return $link !== '' ? $link : jampack_playpass_default_landing_url();
         }
     }
     if ( jampack_user_has_active_subscription( $uid ) ) {

--- a/public_html/wp-content/themes/jampack/includes/elements/playpass-redirections.php
+++ b/public_html/wp-content/themes/jampack/includes/elements/playpass-redirections.php
@@ -3,7 +3,7 @@ if (!defined('ABSPATH')) {
     die('You are not allowed to call this page directly.');
 }
 
-// TODO: Refactor this file for player-rewards redirection
+// TODO: Refactor subscription redirect helpers (Play Pass hub: /play-pass/).
 
 /**
  * Play Pass Subscription Redirections
@@ -45,7 +45,7 @@ function jampack_landing_url_for_membership_product( $product_id ) {
 
 /**
  * Default landing for Play Pass products without a tier row in jampack_subscription_tier_landing_map().
- * Uses the published "play-pass" page when present, otherwise /player-rewards/.
+ * Canonical path: https://jampack.org/play-pass/ — uses the published page permalink when found, else /play-pass/.
  */
 function jampack_playpass_default_landing_url() {
     static $cached = null;
@@ -59,7 +59,7 @@ function jampack_playpass_default_landing_url() {
             return $cached = $link;
         }
     }
-    return $cached = home_url( '/player-rewards/' );
+    return $cached = home_url( '/play-pass/' );
 }
 
 /**


### PR DESCRIPTION
- Map MemberPress product 1269 to page 81; sync early-access and nav menu rules.
- Resolve default Play Pass landing from the play-pass page permalink when it exists, else /player-rewards/.